### PR TITLE
feat(armarserver): Add fix for create profile directory

### DIFF
--- a/lgsm/config-default/config-lgsm/armarserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/armarserver/_default.cfg
@@ -14,9 +14,10 @@ queryport="17777"
 
 # Profile Name
 serverprofile="server"
+serverprofilefullpath="${serverfiles}/profiles/${serverprofile}"
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
-startparameters="-config ${servercfgfullpath} -profile ${serverfiles}/profiles/${serverprofile}"
+startparameters="-config ${servercfgfullpath} -profile ${serverprofilefullpath}"
 
 #### LinuxGSM Settings ####
 

--- a/lgsm/config-default/config-lgsm/armarserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/armarserver/_default.cfg
@@ -12,8 +12,11 @@
 # https://community.bistudio.com/wiki/Arma_Reforger:Server_Hosting
 queryport="17777"
 
+# Profile Name
+serverprofile="server"
+
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
-startparameters="-config ${servercfgfullpath}"
+startparameters="-config ${servercfgfullpath} -profile ${serverfiles}/profiles/${serverprofile}"
 
 #### LinuxGSM Settings ####
 
@@ -151,7 +154,7 @@ consoleinteract="no"
 ## Game Server Details
 # Do not edit
 gamename="Arma Reforger"
-engine="realvirtuality"
+engine="enfusion"
 glibc="2.27"
 
 #### Directories ####

--- a/lgsm/functions/core_functions.sh
+++ b/lgsm/functions/core_functions.sh
@@ -341,6 +341,11 @@ functionfile="${FUNCNAME[0]}"
 fn_fetch_function
 }
 
+fix_armar.sh(){
+functionfile="${FUNCNAME[0]}"
+fn_fetch_function
+}
+
 fix_bo.sh(){
 functionfile="${FUNCNAME[0]}"
 fn_fetch_function

--- a/lgsm/functions/fix.sh
+++ b/lgsm/functions/fix.sh
@@ -39,6 +39,8 @@ if [ "${commandname}" != "INSTALL" ]&&[ -z "${fixbypass}" ]; then
 
 	if  [ "${shortname}" == "arma3" ]; then
 		fix_arma3.sh
+	elif [ "${shortname}" == "armar" ]; then
+		fix_armar.sh
 	elif [ "${shortname}" == "ark" ]; then
 		fix_ark.sh
 	elif [ "${shortname}" == "bo" ]; then

--- a/lgsm/functions/fix_armar.sh
+++ b/lgsm/functions/fix_armar.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# LinuxGSM fix_armar.sh module
+# Author: Daniel Gibbs
+# Contributors: http://linuxgsm.com/contrib
+# Website: https://linuxgsm.com
+# Description: Resolves an issue with Arma Reforger.
+
+functionselfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+# Fixes: Profile directory doesn't exist.
+if [ ! -d "${serverprofilefullpath}" ]; then
+	fixname="Profile directory doesn't exist"
+	fn_fix_msg_start
+	mkdir -p "${serverprofilefullpath}"
+	fn_fix_msg_end
+fi


### PR DESCRIPTION
# Description

Arma Reforger need profile directory to start without crash.
Also added fix for automate create that directory.

Cosmetic change `engine="realvirtuality"` to `engine="enfusion"`

Important note: To be able to connect to server is needed to change `"gameHostRegisterBindAddress"` in `armarserver_config.json`  to proper IP address. `0.0.0.0` not working, player can't connect from server browser.
`"gameHostBindAddress"` can be `0.0.0.0`.

Tested on: Ubuntu Server 20.04.4 LTS